### PR TITLE
refactor: query team members from data directory

### DIFF
--- a/assets/data/team.json
+++ b/assets/data/team.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id": 0,
+    "name": "Samuel Adetunji",
+    "title": "GDSC Lead",
+    "image": "https://media-exp1.licdn.com/dms/image/C4E03AQFA4qZDyN1hsA/profile-displayphoto-shrink_400_400/0/1642438096694?e=2147483647&v=beta&t=oNBgN4xJrxK8caXc1OitCNJBmtBme05QnySn7T7N7xM",
+    "linkedInURL": "https://www.linkedin.com/in/sadetunji/"
+  },
+  {
+    "id": 1,
+    "name": "Ahmed Bayoumi",
+    "title": "HackWesTX Lead",
+    "image": "https://media-exp1.licdn.com/dms/image/C4E03AQFCZre-_cGGBA/profile-displayphoto-shrink_400_400/0/1573610087349?e=2147483647&v=beta&t=bQVsnyBW5trdqKBuWOHm7uGdHljkRmsmWTFBO-9KTmo",
+    "linkedInURL": "https://www.linkedin.com/in/ahmed-bayoumi/"
+  },
+  {
+    "id": 2,
+    "name": "Garret Carmouche",
+    "title": "Finance Lead",
+    "image": "https://media-exp1.licdn.com/dms/image/C4E03AQFlLuF0duOgEw/profile-displayphoto-shrink_400_400/0/1568575754744?e=1653523200&v=beta&t=OoS57nBquyCAxhwdYCqQ_Q8jhx2-BmWF5oh0cRPz-NY",
+    "linkedInURL": "https://www.linkedin.com/in/garret-carmouche/"
+  },
+  {
+    "id": 3,
+    "name": "Minoshun Renganathan",
+    "title": "Marketing Lead",
+    "image": "https://res.cloudinary.com/startup-grind/image/upload/c_fill,dpr_3,f_auto,g_face,h_100,q_auto:good,w_130/v1/gcs/platform-data-dsc/avatars/minoshun_renganathan_QQIumau.jpeg",
+    "linkedInURL": "https://www.linkedin.com/in/minoshun-renganathan/"
+  },
+  {
+    "id": 4,
+    "name": "Arnob Roy",
+    "title": "Event Planning Lead",
+    "image": "https://media-exp1.licdn.com/dms/image/C4D03AQHly8NI2GTw1w/profile-displayphoto-shrink_800_800/0/1636159388835?e=2147483647&v=beta&t=PLkQBXxilHhPCMocnSJ9Uul24a7kVhwkw84lbyn38Z0",
+    "linkedInURL": "https://www.linkedin.com/in/arnob-roy-58762569/"
+  },
+  {
+    "id": 5,
+    "name": "Sahil Shamdasani",
+    "title": "Project Lead",
+    "image": "https://media-exp1.licdn.com/dms/image/C4E03AQHIYT6y4EThfg/profile-displayphoto-shrink_400_400/0/1649251643207?e=1657756800&v=beta&t=Y2K11zCgtkIDFFJsVYMFVEC-jCEVT2hdFpkH2KHdtqM",
+    "linkedInURL": "https://www.linkedin.com/in/sahil-shamdasani/"
+  },
+  {
+    "id": 6,
+    "name": "Shruti Nagawekar",
+    "title": "Code the Shift - Founder",
+    "image": "https://media-exp1.licdn.com/dms/image/C4E03AQGpnvlIAPjG_w/profile-displayphoto-shrink_800_800/0/1638852604020?e=2147483647&v=beta&t=KHqK_l4ZjD4bLLntv7zodY_KJb3EgAhikI_Ewr7Fcjg",
+    "linkedInURL": "https://www.linkedin.com/in/shruti-nagawekar/"
+  }
+]

--- a/components/home/Team.tsx
+++ b/components/home/Team.tsx
@@ -1,5 +1,6 @@
 import { Typography, Grid } from "@mui/material";
 import TeamMember from "../../components/home/TeamMember";
+import team from "../../assets/data/team.json";
 
 const Team = () => {
   return (
@@ -9,50 +10,18 @@ const Team = () => {
         <Typography variant="h4">Our Core Team</Typography>
       </Grid>
       <Grid container direction="row" justifyContent="space-evenly">
-        <TeamMember
-          title="GDSC Lead"
-          name="Samuel Adetunji"
-          link="https://media-exp1.licdn.com/dms/image/C4E03AQFA4qZDyN1hsA/profile-displayphoto-shrink_400_400/0/1642438096694?e=2147483647&v=beta&t=oNBgN4xJrxK8caXc1OitCNJBmtBme05QnySn7T7N7xM"
-          linkedIn="https://www.linkedin.com/in/sadetunji/"
-        />
-        <TeamMember
-          title="HackWesTX Lead"
-          name="Ahmed Bayoumi"
-          link="https://media-exp1.licdn.com/dms/image/C4E03AQFCZre-_cGGBA/profile-displayphoto-shrink_400_400/0/1573610087349?e=2147483647&v=beta&t=bQVsnyBW5trdqKBuWOHm7uGdHljkRmsmWTFBO-9KTmo"
-          linkedIn="https://www.linkedin.com/in/ahmed-bayoumi/"
-        />
-        <TeamMember
-          title="Finance Lead"
-          name="Garret Carmouche"
-          link="https://media-exp1.licdn.com/dms/image/C4E03AQFlLuF0duOgEw/profile-displayphoto-shrink_400_400/0/1568575754744?e=1653523200&v=beta&t=OoS57nBquyCAxhwdYCqQ_Q8jhx2-BmWF5oh0cRPz-NY"
-          linkedIn="https://www.linkedin.com/in/garret-carmouche/"
-        />
-        <TeamMember
-          title="Marketing Lead"
-          name="Minoshun Renganathan"
-          link="https://res.cloudinary.com/startup-grind/image/upload/c_fill,dpr_3,f_auto,g_face,h_100,q_auto:good,w_130/v1/gcs/platform-data-dsc/avatars/minoshun_renganathan_QQIumau.jpeg"
-          linkedIn="https://www.linkedin.com/in/minoshun-renganathan/"
-        />
-        <TeamMember
-          title="Event Planning Lead"
-          name="Arnob Roy"
-          link="https://media-exp1.licdn.com/dms/image/C4D03AQHly8NI2GTw1w/profile-displayphoto-shrink_800_800/0/1636159388835?e=2147483647&v=beta&t=PLkQBXxilHhPCMocnSJ9Uul24a7kVhwkw84lbyn38Z0"
-          linkedIn="https://www.linkedin.com/in/arnob-roy-58762569/"
-        />
-        <TeamMember
-          title="Project Lead"
-          name="Sahil Shamdasani"
-          link="https://media-exp1.licdn.com/dms/image/C4E03AQHIYT6y4EThfg/profile-displayphoto-shrink_400_400/0/1649251643207?e=1657756800&v=beta&t=Y2K11zCgtkIDFFJsVYMFVEC-jCEVT2hdFpkH2KHdtqM"
-          linkedIn="https://www.linkedin.com/in/sahil-shamdasani/"
-        />
-        <TeamMember
-          title="Code the Shift - Founder"
-          name="Shruti Nagawekar"
-          link="https://media-exp1.licdn.com/dms/image/C4E03AQGpnvlIAPjG_w/profile-displayphoto-shrink_800_800/0/1638852604020?e=2147483647&v=beta&t=KHqK_l4ZjD4bLLntv7zodY_KJb3EgAhikI_Ewr7Fcjg"
-          linkedIn="https://www.linkedin.com/in/shruti-nagawekar/"
-        />
+        {team.map(({ id, title, name, image, linkedInURL }) => (
+          <TeamMember
+            key={id}
+            title={title}
+            name={name}
+            link={image}
+            linkedIn={linkedInURL}
+          />
+        ))}
       </Grid>
     </Grid>
   );
 };
+
 export default Team;


### PR DESCRIPTION
I simplified the `Team` component by moving the team member data to the data directory and mapping over the array in order to:

- Encourage orthogonality of data and render logic.
- Minimize future refactoring once all of the site content is moved to a database or content management system.

If the team prefers dot notation to the destructured arguments in the `map` callback let me know and I'd be happy to refactor.